### PR TITLE
Add optional oldUser to reloadCurrentUser, make predicate named

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ var subscription = FirebaseUserReloader.onUserReloaded.listen((user) {
 
 // This will trigger a reload and the reloaded user will be emitted by onUserReloaded
 // only if isEmailVerified == true
-FirebaseUserReloader.reloadCurrentUser((user) => user.isEmailVerified);
+FirebaseUserReloader.reloadCurrentUser(predicate: (user) => user.isEmailVerified);
 
 subscription.cancel();
 ```
@@ -87,7 +87,15 @@ the predicate will be ignored and the reloaded user will always be returned.
 
 ```dart
 var user = await FirebaseUserReloader.reloadCurrentUser();
- ```
+```
+
+If you already have the `oldUser`, you can pass it as a named parameter to `reloadCurrentUser`.
+
+
+```dart
+var user = await FirebaseUserReloader.reloadCurrentUser(oldUser: oldUser);
+```
+
 
 If you want to listen for updates on sign-ins, sign-outs and user reloads, use 
 `onAuthStateChangedOrReloaded` instead, it's just a convenient merge of `onUserReloaded` and
@@ -101,7 +109,7 @@ var subscription = FirebaseUserReloader.onAuthStateChangedOrReloaded.listen((use
 
 // This will trigger a reload and the reloaded user will be emitted by onUserReloaded
 // only if isEmailVerified == true
-FirebaseUserReloader.reloadCurrentUser((user) => user.isEmailVerified);
+FirebaseUserReloader.reloadCurrentUser(predicate: (user) => user.isEmailVerified);
 
 subscription.cancel();
 ```

--- a/example/example.dart
+++ b/example/example.dart
@@ -14,5 +14,5 @@ void main() {
   });
 
   FirebaseUserReloader.reloadCurrentUser();
-  FirebaseUserReloader.reloadCurrentUser((user) => user.isEmailVerified);
+  FirebaseUserReloader.reloadCurrentUser(predicate: (user) => user.isEmailVerified);
 }

--- a/lib/firebase_user_stream.dart
+++ b/lib/firebase_user_stream.dart
@@ -43,14 +43,16 @@ class FirebaseUserReloader {
       _onAuthStateChangedOrReloaded;
 
   /// Merges the given [Stream] with [onUserReloaded] as a broadcast [Stream].
-  static Stream<FirebaseUser> _mergeWithOnUserReloaded(Stream<FirebaseUser> stream) {
+  static Stream<FirebaseUser> _mergeWithOnUserReloaded(
+      Stream<FirebaseUser> stream) {
     return Rx.merge([stream, onUserReloaded]).publishValue()..connect();
   }
 
-  /// Reloads the current [FirebaseUser], using an optional predicate to decide
+  /// Reloads the current [FirebaseUser], using an optional [predicate] to decide
   /// if the reloaded [FirebaseUser] should be emitted by [onUserReloaded] or
   /// not. If a predicate isn't provided the reloaded [FirebaseUser] will
-  /// always be emitted.
+  /// always be emitted. An optional [oldUser] is also given, if you already
+  /// have this.
   ///
   /// The reloaded [FirebaseUser] will always be returned, independently of the
   /// predicate's result.
@@ -64,12 +66,16 @@ class FirebaseUserReloader {
   /// });
   ///
   /// // Calling this will print the user, if its email has been verified.
-  /// await FirebaseUserReloader.reloadCurrentUser(FirebaseAuth.instance,
-  ///     (user) => user.isEmailVerified);
+  /// await FirebaseUserReloader.reloadCurrentUser(
+  ///     predicate: (user) => user.isEmailVerified);
   /// ```
-  static Future<FirebaseUser> reloadCurrentUser(
-      [EmissionPredicate predicate]) async {
-    FirebaseUser oldUser = await auth.currentUser();
+  static Future<FirebaseUser> reloadCurrentUser({
+    EmissionPredicate predicate,
+    FirebaseUser oldUser,
+  }) async {
+    if (oldUser == null) {
+      oldUser = await auth.currentUser();
+    }
     // we need to first reload to then get the updated data.
     await oldUser.reload();
     FirebaseUser newUser = await auth.currentUser();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   firebase:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   js:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   rxdart:
     dependency: "direct main"
     description:
@@ -223,7 +223,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -258,7 +258,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -279,7 +279,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
 sdks:
   dart: ">=2.7.0-dev <3.0.0"
   flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/test/firebase_user_stream_test.dart
+++ b/test/firebase_user_stream_test.dart
@@ -55,7 +55,12 @@ void main() {
     test('Reloads emits the new User when predicate is true in onUserReloaded',
         () async {
       expect(FirebaseUserReloader.onUserReloaded, emits(mockNewUser));
-      await FirebaseUserReloader.reloadCurrentUser((_) => true);
+      await FirebaseUserReloader.reloadCurrentUser(predicate: (_) => true);
+    });
+
+    test('Reloads emits the new User when given oldUser in onUserReloaded', () async {
+      expect(FirebaseUserReloader.onUserReloaded, emits(mockNewUser));
+      await FirebaseUserReloader.reloadCurrentUser(oldUser: mockOldUser);
     });
 
     test('Reloads does not emit the new User when predicate is false in '
@@ -65,7 +70,7 @@ void main() {
       });
 
       // Doesn't emit
-      await FirebaseUserReloader.reloadCurrentUser((_) => false);
+      await FirebaseUserReloader.reloadCurrentUser(predicate: (_) => false);
       await Future.delayed(const Duration(milliseconds: 500));
     });
 


### PR DESCRIPTION
Hi,

Regarding my comment on https://github.com/FirebaseExtended/flutterfire/issues/717 

I tested passing my existing `oldUser` to `reloadCurrentUser` and it seemed to work, so here is a PR with that. I made `predicate` a named parameter since `reloadCurrentUser` now accepts two parameters.

Added some docs, README and a simple test also.